### PR TITLE
Set up automated documentation deployment to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,0 +1,53 @@
+name: Publish documents on GitHub pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Configure GitHub Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Build documentation with Sphinx
+        env:
+          MQC3_CLIENT_TOKEN: ${{secrets.TOKEN}}
+        run: |
+          python -m pip install .[sf,dev]
+          cd docs
+          sphinx-apidoc -e -M -f -o source/reference/ ../src/mqc3/
+          make html
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: docs/build/html
+
+  deploy:
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{steps.deployment.outputs.page_url}}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Related Issue
Closes #1

## Summary
This Pull Request introduces a new GitHub Actions workflow (`.github/workflows/pages.yml`) to fully automate the process of building and deploying our project documentation.

## Key Changes
- Adds the `Publish documents on GitHub pages` workflow (file: `.github/workflows/pages.yml`).
- The workflow uses `actions/setup-python@v5` with Python 3.12 to build the Sphinx documentation.
- It leverages `actions/upload-pages-artifact@v4` and `actions/deploy-pages@v4` for the standard, secure GitHub Pages deployment process.
- The documentation build step is simplified, now only requiring the repository secret `TOKEN` (mapped to `MQC3_CLIENT_TOKEN`).

## Testing
- Tested locally by running the build steps successfully.
- The workflow should be tested after merging by verifying that the GitHub Pages site updates correctly.