### PR TITLE
fix: Python 3.13+ における sf オプション由来の scipy ビルド発生の回避

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,8 +62,12 @@ dev = [
   "ipykernel",
 ]
 sf = [
-  "strawberryfields == 0.23.0",
-  "scipy < 1.14",               # To avoid import errors with the strawberryfields package
+  # Note: [sf] is restricted to Python < 3.13 to avoid time-consuming source builds.
+  # Legacy versions of scipy (and its dependencies like numpy) do not provide pre-built wheels for Python 3.13+.
+
+  "strawberryfields == 0.23.0; python_version < '3.13'",
+  "setuptools < 81.0.0; python_version < '3.13'",       # Required to keep 'pkg_resources', which was removed in newer setuptools and is needed by strawberryfields
+  "scipy < 1.14; python_version < '3.13'",              # To avoid import errors with the strawberryfields package
 ]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
## 概要

Python 3.13 以上の環境において、uv 等でのインストール時に sf オプション（Strawberry Fields）向けの古い依存関係が解決対象に含まれ、不要なローカルビルドが発生する問題を修正しました。また、strawberryfields が依存する `pkg_resources` が新しい setuptools で削除されたことによるインポートエラーを回避する修正も合わせて行いました。

## 背景

* 前提: strawberryfields の動作要件として scipy < 1.14 が必要ですが、本プロジェクトにおいて sf オプションは Python 3.10 〜 3.12 のみをサポート対象としています。
* 発生していた問題: Python 3.13 以上の環境で uv を使用してインストールを行う際、sf extra を指定していない場合でも、uv の依存解決時に extras 内の制約がバージョン選択に影響し、sf 内の scipy < 1.14 という制約が考慮されることがあります。
* ビルドのオーバーヘッド: scipy < 1.14 は Python 3.13、3.14 向けのビルド済みホイールを提供していません。そのため、リゾルバがこれを選択するとローカルでのコンパイルが走り、C++ や Fortran のビルド環境が未整備の環境ではインストールが失敗する原因となっていました。

## 変更内容

* sf 内の依存関係（strawberryfields、scipy、setuptools）すべてに ; python_version < '3.13' の環境マーカーを追加しました。これにより、Python 3.13 以上の環境では sf グループの制約が完全に無視され、dev グループ等で定義されている最新の scipy (>= 1.14) が正しく選択されるようになります。
* setuptools を < 81.0.0 に固定しています。これは strawberryfields が依存している pkg_resources が setuptools 81.0.0 以降で削除されたため、インポートエラーが発生するためです。この制約もマーカーにより Python 3.13 以上では無視されます。

## 影響範囲

* Python 3.10 〜 3.12 環境: 従来通り sf オプションを利用可能です。
* Python 3.13 以上環境: sf オプションの制約（strawberryfields、scipy、setuptools のバージョン固定）が適用されなくなり、scipy のビルド問題が解消されます。